### PR TITLE
Team page - improvements to navigation within the page

### DIFF
--- a/about-us.html
+++ b/about-us.html
@@ -673,9 +673,9 @@
 							
 							</div>
 						</section>
-
 						
-									
+					    <a id="go-top" href="#team-overview" class="scrolly" title="Back to the team overview" ></a>
+
 					</article>
 
 				<!-- Footer -->

--- a/about-us.html
+++ b/about-us.html
@@ -49,90 +49,200 @@
 							<p>Our mission is to create a world where every individual has access to the highest quality genomic information and technologies, enabling them to live healthier, longer, and more fulfilling lives. 
 								<br><br>We envision a future where personalized medicine is the standard of care, and where genomics guides the prevention, diagnosis, and treatment of disease.</p>
 						</header>
-						<a href="#one" class="more scrolly">Meet the team</a>
+						<a href="#team-overview" class="more scrolly">Meet the team</a>
 						</div>
 					</section>
 
-						<section id="one" class="wrapper style1 special">
+						<section id="team-overview" class="wrapper style1 special">
 							<div class="inner">
 								<section>
-									<h2>Leadership</h2>
+									<h2><a href="#leadership" class="scrolly">Leadership</a></h2>
 								<div class="box alt">
 									<div class="row gtr-50 gtr-uniform">
-										<div class="col-3"><span class="image fit"><img src="images/Kimberly_Hood_2023-02-09.png" alt="Kim" /></span></div>
-										<div class="col-3"><span class="image fit"><img src="images/Neal_Boerkoel_2023-02-09.png" alt="Neal" /></span></div>
+										<div class="col-3"><span class="image fit">
+											<a href="#Kim" class="scrolly" title="Kimberly Hood">
+											  <img src="images/Kimberly_Hood_2023-02-09.png" alt="Kim" />
+											</a>
+										</span></div>
+										<div class="col-3"><span class="image fit">
+											<a href="#Neal" class="scrolly" title="Neal Boerkoel">
+												<img src="images/Neal_Boerkoel_2023-02-09.png" alt="Neal" />
+											</a>
+										</span></div>
 									</div>
 								</div>
 								</section>
 								<section>
-									<h2>Scientific</h2>
+									<h2><a href="#scientific" class="scrolly">Scientific</a></h2>
 									<div class="box alt">
 										<div class="row gtr-50 gtr-uniform">
-											<div class="col-3"><span class="image fit"><img src="images/Steven_Jones_2023-02-09.png" alt="Steve" /></span></div>
-											<div class="col-3"><span class="image fit"><img src="images/Rosanna_Weksberg_2023-02-09.png" alt="Rosanna" /></span></div>
-											<!-- <div class="col-3"><span class="image fit"><img src="images/Melissa_Haendel_2023-03-09.png" alt="Melissa" /></span></div> -->
-											<div class="col-3"><span class="image fit"><img src="images/Tudor_Oprea_2023-02-09.png" alt="Tudor" /></span></div>
-											<div class="col-3"><span class="image fit"><img src="images/Cheryl_Shuman_2023-03-09.png" alt="Cheryl" /></span></div>
+											<div class="col-3"><span class="image fit">
+												<a href="#Steve" class="scrolly" title="Steven Jones">
+													<img src="images/Steven_Jones_2023-02-09.png" alt="Steve" />
+												</a>
+											</span></div>
+											<div class="col-3"><span class="image fit">
+												<a href="#Rosanna" class="scrolly" title="Rosanna Weksberg">
+													<img src="images/Rosanna_Weksberg_2023-02-09.png" alt="Rosanna" />
+												</a>
+											</span></div>
+											<!-- <div class="col-3"><span class="image fit">
+												<a href="#Melissa" class="scrolly" title="Melissa Haendel">
+													<img src="images/Melissa_Haendel_2023-03-09.png" alt="Melissa" />
+												</a>
+											</span></div> -->
+											<div class="col-3"><span class="image fit">
+												<a href="#Tudor" class="scrolly" title="Tudor Oprea">
+													<img src="images/Tudor_Oprea_2023-02-09.png" alt="Tudor" />
+												</a>
+											</span></div>
+											<div class="col-3"><span class="image fit">
+												<a href="#Cheryl" class="scrolly" title="Cheryl Schuman">
+													<img src="images/Cheryl_Shuman_2023-03-09.png" alt="Cheryl" />
+												</a>
+											</span></div>
 
 									</div>
 								</div>
 								</section>
 								<section>
-									<h2>Medical</h2>
+									<h2><a href="#medical" class="scrolly">Medical</a></h2>
 								<div class="box alt">
 									<div class="row gtr-50 gtr-uniform">
-										<div class="col-3"><span class="image fit"><img src="images/Lorne_Clarke_2023-02-09.png" alt="Lorne" /></span></div>
-										<div class="col-3"><span class="image fit"><img src="images/Hui_Lin_Chin_2023-03-09.png" alt="Hui-Lin" /></span></div>
-										<div class="col-3"><span class="image fit"><img src="images/Stephanie_Huynh_2023-02-09.png" alt="Stephanie" /></span></div>
-										<div class="col-3"><span class="image fit"><img src="images/Miao_He_2023-02-09.png" alt="Miao" /></span></div>
-										<div class="col-3"><span class="image fit"><img src="images/Katie_Dixon_2023-02-09.png" alt="Katie" /></span></div>
-										<div class="col-3"><span class="image fit"><img src="images/Bobbi_Andera_2023-02-09.png" alt="Bobbi" /></span></div>
-										<div class="col-3"><span class="image fit"><img src="images/Karen_Jacob_2023-03-09.png" alt="Karen" /></span></div>
-										<!-- <div class="col-3"><span class="image fit"><img src="images/" alt="Daria" /></span></div> -->
+										<div class="col-3"><span class="image fit">
+											<a href="#Lorne" class="scrolly" title="Lorne Clarke">
+												<img src="images/Lorne_Clarke_2023-02-09.png" alt="Lorne" />
+											</a>
+										</span></div>
+										<div class="col-3"><span class="image fit">
+											<a href="#Hui-Lin" class="scrolly" title="Hui_Lin Chin">
+												<img src="images/Hui_Lin_Chin_2023-03-09.png" alt="Hui-Lin" />
+											</a>
+										</span></div>
+										<div class="col-3"><span class="image fit">
+											<a href="#Stephanie" class="scrolly" title="Stephanie Huynh">
+												<img src="images/Stephanie_Huynh_2023-02-09.png" alt="Stephanie" />
+											</a>
+										</span></div>
+										<div class="col-3"><span class="image fit">
+											<a href="#Miao" class="scrolly" title="Miao He">
+												<img src="images/Miao_He_2023-02-09.png" alt="Miao" />
+											</a>
+										</span></div>
+										<div class="col-3"><span class="image fit">
+											<a href="#Katie" class="scrolly" title="Katie Dixon">
+												<img src="images/Katie_Dixon_2023-02-09.png" alt="Katie" />
+											</a>
+										</span></div>
+										<div class="col-3"><span class="image fit">
+											<a href="#Bobbi" class="scrolly" title="Bobbi Andera">
+												<img src="images/Bobbi_Andera_2023-02-09.png" alt="Bobbi" />
+											</a>
+										</span></div>
+										<div class="col-3"><span class="image fit">
+											<a href="#Karen" class="scrolly" title="Karen Jacob">
+												<img src="images/Karen_Jacob_2023-03-09.png" alt="Karen" />
+											</a>
+										</span></div>
+										<!-- <div class="col-3"><span class="image fit">
+											<a href="#Daria" class="scrolly" title="Daria">
+												<img src="images/" alt="Daria" />
+											</a>
+										</span></div> -->
 									</div>
 								</div>
 							</section>
 
 							<section>
-								<h2>Technical</h2>
+								<h2><a href="#technical" class="scrolly">Technical</a></h2>
 							<div class="box alt">
 								<div class="row gtr-50 gtr-uniform">
-									<div class="col-3"><span class="image fit"><img src="images/Phillip_Richmond_2023-02-09.png" alt="Phil" /></span></div>
-									<div class="col-3"><span class="image fit"><img src="images/Amalina_Sani_2023-02-09.png" alt="Amalina" /></span></div>
-									<div class="col-3"><span class="image fit"><img src="images/Michael_Groner_2023-02-09.png" alt="Groner" /></span></div>
-									<div class="col-3"><span class="image fit"><img src="images/Sanaa_Choufani_2023-02-09.png" alt="Sanaa" /></span></div>
-									<div class="col-3"><span class="image fit"><img src="images/Yaoqing_Shen_2023-03-09.png" alt="Yaoqing" /></span></div>
+									<div class="col-3"><span class="image fit">
+										<a href="#Phil" class="scrolly" title="Phillip Richmond">
+											<img src="images/Phillip_Richmond_2023-02-09.png" alt="Phil" />
+										</a>
+									</span></div>
+									<div class="col-3"><span class="image fit">
+										<a href="#Groner" class="scrolly" title="Michael Groner">
+											<img src="images/Michael_Groner_2023-02-09.png" alt="Groner" />
+										</a>
+									</span></div>
+									<div class="col-3"><span class="image fit">
+										<a href="#Amalina" class="scrolly" title="Amalina Sani">
+											<img src="images/Amalina_Sani_2023-02-09.png" alt="Amalina" />
+										</a>
+									</span></div>
+									<div class="col-3"><span class="image fit">
+										<a href="#Sanaa" class="scrolly" title="Sanaa Choufani">
+											<img src="images/Sanaa_Choufani_2023-02-09.png" alt="Sanaa" />
+										</a>
+									</span></div>
+									<div class="col-3"><span class="image fit">
+										<a href="#Yaoqing" class="scrolly" title="Yaoqing Shen">
+											<img src="images/Yaoqing_Shen_2023-03-09.png" alt="Yaoqing" />
+										</a>
+									</span></div>
 								</div>
 							</div>
 							</section>
 
 
 							<section>
-								<h2>Business</h2>
+								<h2><a href="#business" class="scrolly">Business</a></h2>
 							<div class="box alt">
 								<div class="row gtr-50 gtr-uniform">
-									<div class="col-3"><span class="image fit"><img src="images/Tom_Dolan_2023-02-09.png" alt="Tom" /></span></div>
-									<div class="col-3"><span class="image fit"><img src="images/Michael_Raymond_2023-02-09.png" alt="Raymond" /></span></div>
-									<div class="col-3"><span class="image fit"><img src="images/Alireza_Baradaran_2023-02-09.png" alt="Ali" /></span></div>
-									<div class="col-3"><span class="image fit"><img src="images/Meriam_Waqas_2023-02-09.png" alt="Meriam" /></span></div>
-									<div class="col-3"><span class="image fit"><img src="images/Michael_Mboob_2023-02-09.png" alt="Mboob" /></span></div>
-									<div class="col-3"><span class="image fit"><img src="images/Christele_du_Souich_2023-03-09.png" alt="Christele" /></span></div>
-									<!-- <div class="col-3"><span class="image fit"><img src="images/Julie_McMurry_2023-03-09.png" alt="Julie" /></span></div> -->
+									<div class="col-3"><span class="image fit">
+										<a href="#Tom" class="scrolly" title="Tom Dolan">
+											<img src="images/Tom_Dolan_2023-02-09.png" alt="Tom" />
+										</a>
+									</span></div>
+									<div class="col-3"><span class="image fit">
+										<a href="#Raymond" class="scrolly" title="Michael Raymond">
+											<img src="images/Michael_Raymond_2023-02-09.png" alt="Raymond" />
+										</a>
+									</span></div>
+									<div class="col-3"><span class="image fit">
+										<a href="#Ali" class="scrolly" title="Alireza Baradaran">
+											<img src="images/Alireza_Baradaran_2023-02-09.png" alt="Ali" />
+										</a>
+									</span></div>
+									<div class="col-3"><span class="image fit">
+										<a href="#Mboob" class="scrolly" title="Michael Mboob">
+											<img src="images/Michael_Mboob_2023-02-09.png" alt="Mboob" />
+										</a>
+									</span></div>
+									<div class="col-3"><span class="image fit">
+										<a href="#Meriam" class="scrolly" title="Meriam Waqas">
+											<img src="images/Meriam_Waqas_2023-02-09.png" alt="Meriam" />
+										</a>
+									</span></div>
+									<div class="col-3"><span class="image fit">
+										<a href="#Christele" class="scrolly" title="Christele_du Souich">
+											<img src="images/Christele_du_Souich_2023-03-09.png" alt="Christele" />
+										</a>
+									</span></div>
+									<!-- <div class="col-3"><span class="image fit">
+										<a href="#Julie" class="scrolly" title="Julie McMurry">
+											<img src="images/Julie_McMurry_2023-03-09.png" alt="Julie" />
+										</a>
+									</span></div> -->
 								</div>
 							</div>
 							</section>
 
-							<a href="#two" class="more scrolly">Learn More</a>
+							<a href="#team-details" class="more scrolly">Learn More</a>
 
 						</section>
 
-						<section id="two" class="wrapper style5">
+					<article id="team-details">
+
+						<section id="leadership" class="wrapper style5">
 							<div class="inner">
 								<header class="major">
 									<h2>Leadership</h2>
 								</header>	
 								
-								<div class="row">
+								<div id="Kim" class="row">
 									<div class="col-4">
 										<span class="image fit"><img src="images/Kimberly_Hood_2023-02-09.png" alt="" /></span>
 									</div>
@@ -147,7 +257,7 @@
 									</div>
 								</div><hr/>
 
-								<div class="row">
+								<div id="Neal" class="row">
 									<div class="col-4">
 										<span class="image fit"><img src="images/Neal_Boerkoel_2023-02-09.png" alt="" /></span>
 									</div>
@@ -166,13 +276,13 @@
 
 
 
-						<section id="five" class="wrapper style5">
+						<section id="scientific" class="wrapper style5">
 							<div class="inner">
 								<header class="major">
 									<h2>Scientific</h2>
 								</header>
 
-								<div class="row">
+								<div id="Steve" class="row">
 									<div class="col-4">
 										<span class="image fit"><img src="images/Steven_Jones_2023-02-09.png" alt="" /></span>
 									</div>
@@ -187,7 +297,7 @@
 									</div>
 								</div><hr/>
 
-								<div class="row">
+								<div id="Rosanna" class="row">
 									<div class="col-4">
 										<span class="image fit"><img src="images/Rosanna_Weksberg_2023-02-09.png" alt="" /></span>
 									</div>
@@ -202,7 +312,7 @@
 									</div>
 								</div><hr/>
 
-								<!-- <div class="row">
+								<!-- <div id="Melissa" class="row">
 									<div class="col-4">
 										<span class="image fit"><img src="images/Melissa_Haendel_2023-03-09.png" alt="" /></span>
 									</div>
@@ -216,7 +326,7 @@
 								</div><hr/> -->
 
 								
-								<div class="row">
+								<div id="Tudor" class="row">
 									<div class="col-4">
 										<span class="image fit"><img src="images/Tudor_Oprea_2023-02-09.png" alt="" /></span>
 									</div>
@@ -232,7 +342,7 @@
 								</div><hr/>
 
 
-								<div class="row">
+								<div id="Cheryl" class="row">
 									<div class="col-4">
 										<span class="image fit"><img src="images/Cheryl_Shuman_2023-03-09.png" alt="" /></span>
 									</div>
@@ -252,13 +362,13 @@
 							</div>
 						</section>
 
-						<section id="four" class="wrapper style5">
+						<section id="medical" class="wrapper style5">
 							<div class="inner">
 								<header class="major">
 									<h2>Medical</h2>
 								</header>
 
-								<div class="row">
+								<div id="Lorne" class="row">
 									<div class="col-4">
 										<span class="image fit"><img src="images/Lorne_Clarke_2023-02-09.png" alt="" /></span>
 									</div>
@@ -274,7 +384,7 @@
 								</div><hr/>
 
 
-								<div class="row">
+								<div id="Hui-Lin" class="row">
 									<div class="col-4">
 										<span class="image fit"><img src="images/Hui_Lin_Chin_2023-03-09.png" alt="" /></span>
 									</div>
@@ -290,7 +400,7 @@
 								</div><hr/>
 
 
-								<div class="row">
+								<div id="Stephanie" class="row">
 									<div class="col-4">
 										<span class="image fit"><img src="images/Stephanie_Huynh_2023-02-09.png" alt="" /></span>
 									</div>
@@ -305,7 +415,7 @@
 									</div>
 								</div><hr/>
 
-								<div class="row">
+								<div id="Miao" class="row">
 									<div class="col-4">
 										<span class="image fit"><img src="images/Miao_He_2023-02-09.png" alt="" /></span>
 									</div>
@@ -320,7 +430,7 @@
 									</div>
 								</div><hr/>
 
-								<div class="row">
+								<div id="Katie" class="row">
 									<div class="col-4">
 										<span class="image fit"><img src="images/Katie_Dixon_2023-02-09.png" alt="" /></span>
 									</div>
@@ -336,7 +446,7 @@
 								</div><hr/>
 
 
-								<div class="row">
+								<div id="Bobbi" class="row">
 									<div class="col-4">
 										<span class="image fit"><img src="images/Bobbi_Andera_2023-02-09.png" alt="" /></span>
 									</div>
@@ -351,7 +461,7 @@
 									</div>
 								</div><hr/>
 
-								<div class="row">
+								<div id="Karen" class="row">
 									<div class="col-4">
 										<span class="image fit"><img src="images/Karen_Jacob_2023-03-09.png" alt="" /></span>
 									</div>
@@ -373,13 +483,13 @@
 							</div>
 						</section>
 
-						<section id="six" class="wrapper style5">
+						<section id="technical" class="wrapper style5">
 							<div class="inner">
 								<header class="major">
 									<h2>Technical</h2>
 								</header>
 
-								<div class="row">
+								<div id="Phil" class="row">
 									<div class="col-4">
 										<span class="image fit"><img src="images/Phillip_Richmond_2023-02-09.png" alt="" /></span>
 									</div>
@@ -395,7 +505,7 @@
 								</div><hr/>
 
 
-								<div class="row">
+								<div id="Groner" class="row">
 									<div class="col-4">
 										<span class="image fit"><img src="images/Michael_Groner_2023-02-09.png" alt="" /></span>
 									</div>
@@ -411,7 +521,7 @@
 								</div><hr/>
 
 
-								<div class="row">
+								<div id="Amalina" class="row">
 									<div class="col-4">
 										<span class="image fit"><img src="images/Amalina_Sani_2023-02-09.png" alt="" /></span>
 									</div>
@@ -426,7 +536,7 @@
 									</div>
 								</div><hr/>
 
-								<div class="row">
+								<div id="Sanaa" class="row">
 									<div class="col-4">
 										<span class="image fit"><img src="images/Sanaa_Choufani_2023-02-09.png" alt="" /></span>
 									</div>
@@ -441,7 +551,7 @@
 									</div>
 								</div><hr/>
 
-								<div class="row">
+								<div id="Yaoqing" class="row">
 									<div class="col-4">
 										<span class="image fit"><img src="images/Yaoqing_Shen_2023-03-09.png" alt="" /></span>
 									</div>
@@ -461,13 +571,13 @@
 						</section>
 
 
-						<section id="three" class="wrapper style5">
+						<section id="business" class="wrapper style5">
 							<div class="inner">
 								<header class="major">
 									<h2>Business</h2>
 								</header>	
 
-								<div class="row">
+								<div id="Tom" class="row">
 									<div class="col-4">
 										<span class="image fit"><img src="images/Tom_Dolan_2023-02-09.png" alt="" /></span>
 									</div>
@@ -482,7 +592,7 @@
 									</div>
 								</div><hr/>
 
-								<div class="row">
+								<div id="Raymond" class="row">
 									<div class="col-4">
 										<span class="image fit"><img src="images/Michael_Raymond_2023-02-09.png" alt="" /></span>
 									</div>
@@ -497,7 +607,7 @@
 									</div>
 								</div><hr/>
 
-								<div class="row">
+								<div id="Ali" class="row">
 									<div class="col-4">
 										<span class="image fit"><img src="images/Alireza_Baradaran_2023-02-09.png" alt="" /></span>
 									</div>
@@ -512,7 +622,7 @@
 									</div>
 								</div><hr/>
 
-								<div class="row">
+								<div id="Mboob" class="row">
 									<div class="col-4">
 										<span class="image fit"><img src="images/Michael_Mboob_2023-02-09.png" alt="" /></span>
 									</div>
@@ -527,7 +637,7 @@
 									</div>
 								</div><hr/>
 
-								<div class="row">
+								<div id="Meriam" class="row">
 									<div class="col-4">
 										<span class="image fit"><img src="images/Meriam_Waqas_2023-02-09.png" alt="" /></span>
 									</div>
@@ -541,8 +651,9 @@
 										</p>
 									</div>
 								</div><hr/>
+
 							
-								<div class="row">
+								<div id="Christele" class="row">
 									<div class="col-4">
 										<span class="image fit"><img src="images/Christele_du_Souich_2023-03-09.png" alt="" /></span>
 									</div>

--- a/assets/css/images/arrowUp.svg
+++ b/assets/css/images/arrowUp.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="30px" height="30px" viewBox="0 0 30 30" zoomAndPan="disable" preserveAspectRatio="none">
+    <style type="text/css"><![CDATA[ line { stroke: #003a5d; stroke-width: 3; } ]]></style>
+	<line x1="0" y1="15" x2="15" y2="0" />
+	<line x1="30" y1="15" x2="15" y2="0" />
+	<line x1="15" y1="30" x2="15" y2="0" />
+</svg>

--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -3967,6 +3967,25 @@ input, select, textarea {
 		background-attachment: scroll;
 	}
 
+/* Back to top link */
+	#go-top {
+		bottom: 1em;
+		float: right;
+		margin: -2em 1em 1em;
+		position: sticky;
+	}
+		#go-top:after {
+			background-image: url("images/arrowUp.svg");
+			background-position: center;
+			background-repeat: no-repeat;
+			background-size: contain;
+			content: '';
+			display: block;
+			height: 1.5em;
+			right: 0;
+			width: 1.5em;
+		}
+
 /* Footer */
 
 	#footer {

--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -365,6 +365,10 @@ input, select, textarea {
 		justify-content: center;
 	}
 
+		.row[id] { /* Rows with a specified id are used for navigation within the page and should have some top padding when scrolled to */
+			padding: .5em 0;
+		}
+
 		.row > * {
 			box-sizing: border-box;
 		}


### PR DESCRIPTION
* Added links from the team overview section to the details sections (both from the titles - "Leadership", "Scientific", ... and the profile pictures)
* Changed the section ids to be more meaningful (e.g. "one" -> "team-overview", "two"->"leadership", etc) for a cleaner look of the URL in noscript mode
* Added a "Back to team overview" link accessible when browsing team profiles
* Some profiles were listed in different order in the overview vs details - reordered for consistency