### PR TITLE
Remove text that is specific to 'First in Class' from the 'Alamya Solutions' intro

### DIFF
--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -4208,6 +4208,7 @@ input, select, textarea {
 }
 
 .solutions-wrapper {
+	padding-top: 1.5em;
 	padding-bottom: 4em;
 	display: -moz-flex;
 	display: -webkit-flex;

--- a/first-in-class.html
+++ b/first-in-class.html
@@ -83,6 +83,10 @@
 							</li>
 						</ol>
 						
+						<p>
+							These tests are performed in a CLIA-certified laboratory with clinical reports reviewed and signed by an ABMGG-certified laboratory geneticist.
+						</p>
+						
 						<h3>Who is this test for?</h3>
 						<ul>
 							<li>Patients needing quick test results to guide management</li>

--- a/index.html
+++ b/index.html
@@ -68,10 +68,10 @@
 									<div>
 										<h3>First in Class</h3>
 										<p>
-											<b>Clinical</b> short-read whole genome with turnaround of 4-6 weeks.
+											<b>Clinical</b> short-read whole genome with reflex to a transcriptome analysis and/or Infinium MethylationEPIC microarray, with turnaround of 4-6 weeks.
+										</p>
+										<p>
 											Rapid testing is also available with a preliminary report in 5 days and final report in 10-14 days.
-											These tests are performed in a CLIA-certified laboratory with clinical reports reviewed and signed by
-											an ABMGG-certified laboratory geneticist.
 										</p>
 									</div>
 									<div class="align-right">

--- a/solutions.html
+++ b/solutions.html
@@ -60,31 +60,26 @@
 
 				<section id="one" class="wrapper style5">
 						<div class="inner">
-							<header class="major align-center">
-								<h3>Precision medicine is predicated on achieving an accurate diagnosis.</h3>
-							</header>
+							<h3>Precision medicine is predicated on achieving an accurate diagnosis.</h3>
 
 							<p>
 								Achieving such precision requires detection of high probability causes and exclusion of alternative causes.
 								Whole genome sequencing and mitochondrial genome sequencing in conjunction with RNA sequencing (transcriptome)
 								and assessment of DNA methylation (epigenome) significantly increases diagnostic precision and yield across a range of genetic diseases. 
 							</p>
-							<p>
-								Enabling this next generation of precision diagnosis, <a href="solutions.html">Alamya Health offers the complete package</a>:
-								whole genome sequencing with reflex to a transcriptome analysis and/or Infinium MethylationEPIC microarray
-								depending on the diagnostic requirements of your patient.
-								Alamya Health can help you find the testing solution that works for you and your patient, and together we can end their diagnostic odyssey.
-							</p>
+
+							<h3>Find the testing solution</a> that works for you and your patient.</h3>
+								
 								
 						<div class="solutions-wrapper">
 							<div class="solution-box wrapper style2">
 							    <div>
 									<h3>First in Class</h3>
 									<p>
-									<b>Clinical</b> short-read whole genome with turnaround of 4-6 weeks.
-									Rapid testing is also available with a preliminary report in 5 days and final report in 10-14 days.
-									These tests are performed in a CLIA-certified laboratory with clinical reports reviewed and signed by
-									an ABMGG-certified laboratory geneticist.
+										<b>Clinical</b> short-read whole genome with reflex to a transcriptome analysis and/or Infinium MethylationEPIC microarray, with turnaround of 4-6 weeks.
+									</p>
+									<p>
+										Rapid testing is also available with a preliminary report in 5 days and final report in 10-14 days.
 									</p>
 								</div>
 								<div class="align-right">


### PR DESCRIPTION
(as requested by Kim)

### Preview the updates Solutions page: https://mgirdea.github.io/ala-web/solutions.html

### Screenshots

The new Solutions page:

![image](https://github.com/alamya-health/alamya-health.github.io/assets/130861038/630ea7af-bd44-4a61-8039-7e6decf741d8)

The "CLIA-certified..." phrase has moved from the "First in Class" blue box to the "First in Class" product page:

![image](https://github.com/alamya-health/alamya-health.github.io/assets/130861038/a8fed4d6-5d8f-4ae0-8bf0-22dc5dc33be7)
